### PR TITLE
Fix default value of g:vimreason_extra_args_expr_reason.

### DIFF
--- a/plugin/reason.vim
+++ b/plugin/reason.vim
@@ -16,7 +16,7 @@ let g:loaded_vimreason = 1
 " User Customizable Config Variables:
 
 if !exists('g:vimreason_extra_args_expr_reason')
-  let g:vimreason_extra_args_expr_reason=''
+  let g:vimreason_extra_args_expr_reason='""'
 endif
 if !exists('g:vimreason_project_airline')
   let g:vimreason_project_airline=1


### PR DESCRIPTION
The extra refmt args get calculated as:
```vimscript
let s:vimreason_extra_args_expr_var = "g:vimreason_extra_args_expr_".type

let s:vimreason_extra_args = ""
if exists(s:vimreason_extra_args_expr_var)
  let s:vimreason_extra_args = eval(eval(s:vimreason_extra_args_expr_var))
endif
```

With a default value of `g:vimreason_extra_args_expr_reason = ''`.
A double eval computing the extra `vimreason_extra_args` based on
`g:vimreason_extra_args_expr_reason` will result in the literal value
`0`. Apparently double eval of an empty string results into plain 0.

This is problematic because refmt gets invoked as `refmt 0 ...rest`.
To solve this problem I initialized the
`vimreason_extra_args_expr_reason` with a string containing an empty
string. The double eval will give us an empty string in case that there
aren't any extra_args_expr.