### PR TITLE
Look for OPAM files and use the first one as project root

### DIFF
--- a/autoload/esy.vim
+++ b/autoload/esy.vim
@@ -107,6 +107,10 @@ function! esy#FetchProjectRoot()
     if filereadable(packageJsonPath)
       return [l:cwd, 'package.json']
     endif
+    let opamFiles = globpath(cwd, '*.opam', 0, 1)
+    if !empty(opamFiles) && filereadable(opamFiles[0])
+      return [l:cwd, opamFiles[0]]
+    endif
     let bsConfigJsonPath = resolve(l:cwd . '/bsconfig.json')
     if filereadable(bsConfigJsonPath)
       " It is unfortunate that we need to read the file just to tell if it has


### PR DESCRIPTION
If there are OPAM files in a project with no JSON files, use the first one as the project root.

This is the first step in supporting several OPAM files, but it does the trick for now.